### PR TITLE
Auto loading target from config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ return {
 ## Options
 Addtionally you can provide the following options. 
 
-- `targetfile [optional]`: Defines the filename of the file this plugin autoloads its target from
 - `config_file [optional]`: Defines the path to config file.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Here is an example of the config file and its possible options.
 
 ```json
 {
-  "target": "pico" // Auto sets the target to the provided value. Has to one of 'tinygo targets' results.
+  "target": "pico" // Auto sets the target to the provided value. Has to be one of 'tinygo targets' results.
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ return {
 Addtionally you can provide the following options. 
 
 - `targetfile [optional]`: Defines the filename of the file this plugin autoloads its target from
+- `config_file [optional]`: Defines the path to config file.
 
 ## Usage
 This plugin provides three different user commands:
@@ -91,8 +92,16 @@ This plugin provides three different user commands:
 
 - `:TinyGoEnv`: This commmand prints the currently configured target, `GOROOT` and `GOFLAGS`.
 
-Alternatively you can add a file (default: `.tinygo`) into your cwd and write your target into the first line.
-This plugin provides two auto commands that read the target from this file and set it. Once on the first `LspAttach`
-on any `.go`-file and secondly on each `BufWritePost` that is performed on the target file.
+Alternatively you can add a file (default: `.tinygo.json`) into your cwd and set your target there.
+This plugin automatically loads this config file on startup and dynamically reloads when the config
+file is changed.
+
+Here is an example of the config file and its possible options.
+
+```json
+{
+  "target": "pico" // Auto sets the target to the provided value. Has to one of 'tinygo targets' results.
+}
+```
 
 I hope you find this useful!

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ to be extremely helpful:
 - [Unofficial Neovim Lua Guide](https://github.com/nanotee/nvim-lua-guide): A great primer on using Lua within Neovim.
 
 - [Linode Neovim Tutorial](https://www.linode.com/docs/guides/write-a-neovim-plugin-with-lua/): Despite the website being
-   very choppy (at least on Safari) and throwing some Vim Script in the mix, this tutorial presents a nice overall structure
-   of what a Neovim plugin looks like.
+  very choppy (at least on Safari) and throwing some Vim Script in the mix, this tutorial presents a nice overall structure
+  of what a Neovim plugin looks like.
 
 - [Lua 5.1 Reference](http://www.lua.org/manual/5.1/manual.html): For everything Lua, nothing beats the official reference.
 
@@ -76,9 +76,9 @@ return {
 ```
 
 ## Options
-Addtionally you can provide the following options. 
+Addtionally you can provide the following options.
 
-- `config_file [optional]`: Defines the path to config file.
+- **`config_file`** [string]: Defines the path to config file.
 
 ## Usage
 This plugin provides three different user commands:
@@ -99,8 +99,10 @@ Here is an example of the config file and its possible options.
 
 ```json
 {
-  "target": "pico" // Auto sets the target to the provided value. Has to be one of 'tinygo targets' results.
+  "target": "pico"
 }
 ```
+
+- **`target`** [string]: Auto sets the target to the provided value. Has to be one of 'tinygo targets' results.
 
 I hope you find this useful!

--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ return {
 }
 ```
 
+## Options
+Addtionally you can provide the following options. 
+
+- `targetfile [optional]`: Defines the filename of the file this plugin autoloads its target from
+
 ## Usage
 This plugin provides three different user commands:
 
@@ -85,5 +90,9 @@ This plugin provides three different user commands:
 - `:TinyGoTargets`: This command will simply list available TinyGo targets, excluding `original`.
 
 - `:TinyGoEnv`: This commmand prints the currently configured target, `GOROOT` and `GOFLAGS`.
+
+Alternatively you can add a file (default: `.tinygo`) into your cwd and write your target into the first line.
+This plugin provides two auto commands that read the target from this file and set it. Once on the first `LspAttach`
+on any `.go`-file and secondly on each `BufWritePost` that is performed on the target file.
 
 I hope you find this useful!

--- a/README.md
+++ b/README.md
@@ -57,13 +57,21 @@ resort to 'pure' API calls if this were to prove an obstacle. Given the pervasiv
 but it is nice to know we can count on some wiggle room!
 
 ## Installation
-This plugin can be installed through regular plugin manages. I use [`packer.nvim`](https://github.com/wbthomason/packer.nvim),
-so it's the example we'll provide. The rest should be rather similar: this plugin requires no settings!
+This plugin can be installed through regular plugin managers.
 
+### [Packer.nvim](https://github.com/wbthomason/packer.nvim)
 ```lua
 use {
     "pcolladosoto/tinygo.nvim",
     config = function() require("tinygo").setup() end
+}
+```
+
+### [Lazy.nvim](https://github.com/wbthomason/packer.nvim)
+```lua
+return {
+    "pcolladosoto/tinygo.nvim",
+    opts = {},
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ use {
 }
 ```
 
-### [Lazy.nvim](https://github.com/wbthomason/packer.nvim)
+### [Lazy.nvim](https://github.com/folke/lazy.nvim)
 ```lua
 return {
     "pcolladosoto/tinygo.nvim",

--- a/lua/tinygo/init.lua
+++ b/lua/tinygo/init.lua
@@ -144,7 +144,10 @@ function M.applyConfigFile()
 		return
 	end
 
-	vim.cmd.TinyGoSetTarget(cfg["target"])
+	local target = cfg["target"]
+	if target then
+		vim.cmd.TinyGoSetTarget(cfg["target"])
+	end
 end
 
 return M

--- a/lua/tinygo/init.lua
+++ b/lua/tinygo/init.lua
@@ -1,5 +1,5 @@
 local M = {
-    config_file = ".tinygo.json",
+	config_file = ".tinygo.json",
 }
 
 function M.setup(opts)
@@ -9,9 +9,9 @@ function M.setup(opts)
 	local ok, goEnvJSON = pcall(vim.fn.json_decode, goEnv)
 	if not ok then vim.print("error parsing the go environment"); return end
 
-    if opts["config_file"] then
-        M.config_file = opts["config_file"]
-    end
+	if opts["config_file"] then
+		M.config_file = opts["config_file"]
+	end
 
 	M["originalGOROOT"]  = goEnvJSON["GOROOT"]
 	M["originalGOFLAGS"] = goEnvJSON["GOFLAGS"]
@@ -37,8 +37,8 @@ function M.setup(opts)
 	vim.api.nvim_create_user_command("TinyGoTargets", M.printTargets, {nargs = 0})
 	vim.api.nvim_create_user_command("TinyGoEnv", M.printEnv, {nargs = 0})
 
-    vim.api.nvim_create_autocmd({"LspAttach"}, {once=true, pattern="*.go", callback=M.applyConfigFile})
-    vim.api.nvim_create_autocmd({"BufWritePost"}, {pattern=M.config_file, callback=M.applyConfigFile})
+	vim.api.nvim_create_autocmd({"LspAttach"}, {once=true, pattern="*.go", callback=M.applyConfigFile})
+	vim.api.nvim_create_autocmd({"BufWritePost"}, {pattern=M.config_file, callback=M.applyConfigFile})
 end
 
 -- As seen on https://neovim.io/doc/user/api.html#nvim_create_user_command(), autocompletions written in
@@ -71,7 +71,7 @@ function M.setTarget(opts)
 				GOROOT  = M["originalGOROOT"],
 				GOFLAGS = M["originalGOFLAGS"]
 			}
-		 })
+		})
 		return
 	end
 
@@ -105,7 +105,7 @@ function M.setTarget(opts)
 			GOROOT = currentGOROOT,
 			GOFLAGS = currentGOFLAGS
 		}
-	 })
+	})
 end
 
 function M.printTargets()
@@ -125,29 +125,26 @@ function M.printEnv()
 end
 
 function M.applyConfigFile()
-    local f = io.open(M.config_file, "r")
-    if not f then
-        return
-    end
+	local f = io.open(M.config_file, "r")
+	if not f then
+		return
+	end
 
-    local ok, rawCfg = pcall(f.read, f, "a")
-    if not ok then
-        vim.print("error reading config file")
-        f:close()
-        return
-    end
-    f:close()
+	local ok, rawCfg = pcall(f.read, f, "a")
+	if not ok then
+		vim.print("error reading config file")
+		f:close()
+		return
+	end
+	f:close()
 
-    local ok, cfg = pcall(vim.json.decode, rawCfg)
-    if not ok then
-        vim.print("error decoding config file")
-        return
-    end
+	local ok, cfg = pcall(vim.json.decode, rawCfg)
+	if not ok then
+		vim.print("error decoding config file")
+		return
+	end
 
-    local target = cfg["target"]
-    if target then
-        vim.cmd.TinyGoSetTarget(target)
-    end
+	vim.cmd.TinyGoSetTarget(cfg["target"])
 end
 
 return M

--- a/lua/tinygo/init.lua
+++ b/lua/tinygo/init.lua
@@ -132,7 +132,7 @@ function M.applyConfigFile()
 
     local ok, rawCfg = pcall(f.read, f, "a")
     if not ok then
-        vim.print("error reading config file: ")
+        vim.print("error reading config file")
         f:close()
         return
     end
@@ -140,7 +140,7 @@ function M.applyConfigFile()
 
     local ok, cfg = pcall(vim.json.decode, rawCfg)
     if not ok then
-        vim.print("error decoding config file: ")
+        vim.print("error decoding config file")
         return
     end
 

--- a/lua/tinygo/init.lua
+++ b/lua/tinygo/init.lua
@@ -37,7 +37,15 @@ function M.setup(opts)
 	vim.api.nvim_create_user_command("TinyGoTargets", M.printTargets, {nargs = 0})
 	vim.api.nvim_create_user_command("TinyGoEnv", M.printEnv, {nargs = 0})
 
-	vim.api.nvim_create_autocmd({"LspAttach"}, {once=true, pattern="*.go", callback=M.applyConfigFile})
+	vim.api.nvim_create_autocmd({"LspAttach"}, {
+		group=vim.api.nvim_create_augroup("TinyGoApplyConfigFile", {}),
+		pattern="*.go",
+		callback=function (ev)
+			if #vim.lsp.get_clients({bufnr=ev.buf, name="gopls"}) > 0 and M.currentTarget == "original" then
+				M.applyConfigFile()
+			end
+		end,
+	})
 	vim.api.nvim_create_autocmd({"BufWritePost"}, {pattern=M.config_file, callback=M.applyConfigFile})
 end
 


### PR DESCRIPTION
This PR adds the possibility to add a file to the root of a TinyGo project that the user can add a target into. This provided target is then automatically loaded when the user enters a `.go` file inside that scope. The target is also dynamically updated when the user changes the file.

Default behaviours:

- The default name of the target file is `.tinygo`
- The user has to place the target into the first line of the target file

Feel free to give some feedback especially about the default file name and about the file format.